### PR TITLE
build.sh: fix git fetch for tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,6 +134,8 @@ release() {
     git submodule update --init --checkout
     git remote add pcengines https://github.com/pcengines/coreboot.git
     git fetch pcengines
+    # fetch tags additionally, sometimes git fetch does not find all revisions
+    git fetch pcengines -t
     git checkout -f $1
     git submodule update --init --checkout
     tag=$(git describe --tags --abbrev=0 ${1})
@@ -180,6 +182,8 @@ release_ci() {
     git submodule update --init --checkout
     git remote add pcengines https://github.com/pcengines/coreboot.git
     git fetch pcengines
+    # fetch tags additionally, sometimes git fetch does not find all revisions
+    git fetch pcengines -t
     git checkout -f $1
     git submodule update --init --checkout
     check_if_legacy $(git describe --tags --abbrev=0 ${1})


### PR DESCRIPTION
Due to incrasing number of tags git fetch command did not download
all possible revisions causing the build to fail.

Fetch tags separately to ensure every revisions will be available.

Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>