### PR TITLE
build.sh: fix missing parameter to pce-fw-builder.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -247,7 +247,8 @@ release_ci() {
     if [[ ${tag:0:1} == "v" ]] ; then tag=${tag:1}; fi
     check_if_legacy $tag
     legacy=$?
-
+    # always verify ssl certificates in CI
+    sslverify=true 
 
     cd /home/coreboot/pce-fw-builder
 
@@ -257,7 +258,7 @@ release_ci() {
     # remove tag|branch from options
     shift
 
-    scripts/pce-fw-builder.sh $legacy $*
+    scripts/pce-fw-builder.sh $legacy $sslverify $*
 
     pwd
     ls -al /home/coreboot/coreboot/build/


### PR DESCRIPTION
This fixes building firmware in GitLab CI after the latest release.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>